### PR TITLE
Update workers README and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,42 +49,49 @@ services:
 
 ### 🦀 Cloudflare Workers
 
-#### Running locally:
+```sh
+cd worker
+```
 
--
-    ```sh
-    cd worker
-    ```
-- Copy `.dev.vars.example` to [`.dev.vars`](https://developers.cloudflare.com/workers/configuration/environment-variables/#interact-with-environment-variables-locally) and fill in the values:
+#### Run the worker locally
 
-    ```sh
-    # .dev.vars is Cloudflare Wrangler's .env equivalent
-    cp .dev.vars.example .dev.vars
-    ```
-- Run the worker locally:
-    ```sh
-    pnpm dev
-    ```
-#### Deploying:
+```sh
+cp .dev.vars.example .dev.vars
+```
 
-- Create a [**KV namespace**](https://developers.cloudflare.com/kv/get-started/#3-create-a-kv-namespace) via `Wrangler`:
-    ```sh
-    pnpm wrangler kv:namespace create <YOUR_NAMESPACE>
-    ```
-- From the output, copy the `id` and replace the one in [`wrangler.toml`](./worker/wrangler.toml) line 8 with it. The `binding` value should remain as `enstate-1` regardless of what you named yours when you created it,
+Edit your `.dev.vars` file at this time to include environment variables for `UNIVERSAL_RESOLVER`, `RPC_URL` (optional) and `OPENSEA_API_KEY` (optional).
 
-- Deploy the worker:
+To run the worker locally you can now run:
 
-    ```sh
-    pnpm wrangler deploy
-    ```
-- Upload your secrets:
-    ```sh
-    echo "https://rpc.ankr.com/eth/XXXXXX" | pnpm wrangler secret put RPC_URL
-    echo "XXXXX" | pnpm wrangler secret put OPENSEA_API_KEY
-    ```
+```
+pnpm dev
+```
+
+#### Deploying to Cloudflare Workers
+
+Create a [**KV namespace**](https://developers.cloudflare.com/kv/get-started/#3-create-a-kv-namespace) via `wrangler` or the Cloudflare dashboard.
+
+```sh
+pnpm wrangler kv:namespace create <YOUR_NAMESPACE>
+```
+
+Copy the `id` of your newly created KV namespace to your [`wrangler.toml`](./worker/wrangler.toml). The `binding` value should remain as `enstate-1` regardless of what you named yours when you created it.
+
+Deploy the worker:
+
+```sh
+pnpm wrangler deploy
+```
+
+Upload your secrets:
+
+```sh
+echo "https://rpc.ankr.com/eth/XXXXXX" | pnpm wrangler secret put RPC_URL
+echo "XXXXX" | pnpm wrangler secret put OPENSEA_API_KEY
+```
 
 Additionally, there is a hosted instance available at [worker.enstate.rs](https://worker.enstate.rs).
+
 ## Contributing
 
 ### Standalone Server
@@ -95,4 +102,8 @@ cd server && cargo run -p enstate
 
 ### Cloudflare Worker
 
-See [running Cloudflare Workers locally](#running-locally).
+```sh
+cd worker && pnpm dev
+```
+
+For more information on running the worker locally, please see [running Cloudflare Workers locally](#run-the-worker-locally).

--- a/README.md
+++ b/README.md
@@ -47,25 +47,52 @@ services:
             - 6379:6379
 ```
 
-### 🦀 Cloudflare Worker
+### 🦀 Cloudflare Workers
 
-Running the cloudflare worker is as easy as running the following command:
+#### Running locally:
+
+-
+    ```sh
+    cd worker
+    ```
+- Copy `.dev.vars.example` to [`.dev.vars`](https://developers.cloudflare.com/workers/configuration/environment-variables/#interact-with-environment-variables-locally) and fill in the values:
+
+    ```sh
+    # .dev.vars is Cloudflare Wrangler's .env equivalent
+    cp .dev.vars.example .dev.vars
+    ```
+- Run the worker locally:
+    ```sh
+    pnpm dev
+    ```
+#### Deploying:
+
+- Create a [**KV namespace**](https://developers.cloudflare.com/kv/get-started/#3-create-a-kv-namespace) via `Wrangler`:
+    ```sh
+    pnpm wrangler kv:namespace create <YOUR_NAMESPACE>
+    ```
+- From the output, copy the `id` and replace the one in [`wrangler.toml`](./worker/wrangler.toml) line 8 with it. The `binding` value should remain as `enstate-1` regardless of what you named yours when you created it,
+
+- Deploy the worker:
+
+    ```sh
+    pnpm wrangler deploy
+    ```
+- Upload your secrets:
+    ```sh
+    echo "https://rpc.ankr.com/eth/XXXXXX" | pnpm wrangler secret put RPC_URL
+    echo "XXXXX" | pnpm wrangler secret put OPENSEA_API_KEY
+    ```
+
 Additionally, there is a hosted instance available at [worker.enstate.rs](https://worker.enstate.rs).
-
-```sh
-cd worker && pnpx wrangler deploy
-```
-
 ## Contributing
 
 ### Standalone Server
 
 ```sh
-cargo run -p enstate
+cd server && cargo run -p enstate
 ```
 
 ### Cloudflare Worker
 
-```sh
-cd worker && pnpm dev
-```
+See [running Cloudflare Workers locally](#running-locally).

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -1,2 +1,2 @@
 OPENSEA_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-UNIVERSAL_RESOLVER=0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62s
+

--- a/worker/package.json
+++ b/worker/package.json
@@ -8,6 +8,6 @@
 		"dev": "wrangler dev"
 	},
 	"devDependencies": {
-		"wrangler": "^3.19.0"
+		"wrangler": "^3.23.0"
 	}
 }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,3 +1,4 @@
+#: schema https://github.com/cloudflare/workers-sdk/files/12887590/wrangler.schema.json
 name = "enstate-worker"
 main = "build/worker/shim.mjs"
 compatibility_date = "2023-03-22"
@@ -14,4 +15,4 @@ kv_namespaces = [
 command = "cargo install -q worker-build && worker-build --release"
 
 [vars]
-OPENSEA_API_KEY="xxxx"
+UNIVERSAL_RESOLVER="0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62"


### PR DESCRIPTION
- Update `wrangler` version to latest,
- Update `wrangler.toml`:
  - pass schema at the top so that editors can provide autocomplete (https://taplo.tamasfe.dev/),
  - move `OPENSEA_API_KEY` from `wrangler.toml` to `.dev.vars` [since it's a secret](https://developers.cloudflare.com/workers/configuration/environment-variables/#compare-secrets-and-environment-variables),
  - move `UNIVERSAL_RESOLVER` from `.dev.vars` to `wrangler.toml` [since it's not a secret](https://developers.cloudflare.com/workers/configuration/environment-variables/#compare-secrets-and-environment-variables),
- Update directions on how to run Workers locally,
- Update directions on how to deploy workers.

After these changes I was able to successfully run the Workers locally and deploy it as well: https://ens.evm.workers.dev/n/luc.eth